### PR TITLE
Add the ability to add options for activerecord_import

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -87,7 +87,14 @@ class SeedDump
         io.write(",\n  ") unless last_batch
       end
 
-      io.write("\n])\n")
+      io.write("\n]")
+      if options[:validate]==false && options[:import] 
+        io.write(",:validate => #{options[:validate]}")
+      end 
+      if options[:serialized]==false && options[:import] 
+        io.write(",:serialized => #{options[:serialized]}")
+      end 
+      io.write(")\n")
 
       if options[:file].present?
         nil


### PR DESCRIPTION
There are two options, one already in the gem, and one would be added. 
The first is to avoid validation (which is good, considering you just need to load the data that previously exist in a similar data). 
The second is to avoid the serialization done by activerecord_import on serialized fields, that doesn't seem to work well in all cases. (works only for hashes?)
